### PR TITLE
GitHub Icon Added

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,10 +1,11 @@
 import { useState, useEffect } from "react";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faCheck, faTimes, faChevronDown } from "@fortawesome/free-solid-svg-icons";
+import { faGithub } from "@fortawesome/free-brands-svg-icons";
 import CodeEditor from "./components/Editor";
 import MarkdownRenderer from "./components/MarkdownRenderer";
 import { ModuleService } from "./services/moduleService.js";
-import type { ModuleContent, TestSuiteResult, RunResult, Module } from "./services/moduleService.js";
+import type { ModuleContent, TestSuiteResult, RunResult, Module } from "./services/moduleService";
 
 type Difficulty = 'Beginner' | 'Intermediate' | 'Advanced';
 type Tab = 'Lab' | 'Exercise';
@@ -231,7 +232,7 @@ export default function App() {
               </div>
             </div>
 
-            {/* Module Selector */}
+            {/* Top Right: Module Selector + GitHub Link */}
             <div className="flex items-center space-x-3">
               <div className="relative module-dropdown">
                 <button 
@@ -276,6 +277,16 @@ export default function App() {
                   </div>
                 )}
               </div>
+              {/* GitHub Link Icon */}
+              <a
+                href="https://github.com/backend2lab/backend2lab"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-tactical-text-secondary hover:text-tactical-primary transition-colors"
+                title="View on GitHub"
+              >
+                <FontAwesomeIcon icon={faGithub} size="2x" />
+              </a>
             </div>
           </div>
         </div>

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -232,7 +232,7 @@ export default function App() {
               </div>
             </div>
 
-            {/* Top Right: Module Selector + GitHub Link */}
+            {/* Top Right:- Module Selector + GitHub Link */}
             <div className="flex items-center space-x-3">
               <div className="relative module-dropdown">
                 <button 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,6 +57,12 @@ importers:
       '@types/react-dom':
         specifier: ^19.1.7
         version: 19.1.9(@types/react@19.1.12)
+      '@typescript-eslint/eslint-plugin':
+        specifier: ^8.41.0
+        version: 8.41.0(@typescript-eslint/parser@8.41.0(eslint@9.34.0(jiti@1.21.7))(typescript@5.8.3))(eslint@9.34.0(jiti@1.21.7))(typescript@5.8.3)
+      '@typescript-eslint/parser':
+        specifier: ^8.41.0
+        version: 8.41.0(eslint@9.34.0(jiti@1.21.7))(typescript@5.8.3)
       '@vitejs/plugin-react':
         specifier: ^5.0.0
         version: 5.0.2(vite@7.1.3(@types/node@18.16.20)(jiti@1.21.7)(tsx@4.20.5)(yaml@2.8.1))


### PR DESCRIPTION
I have added the github icon that has the link of this repository "https://github.com/backend2lab/backend2lab/"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a GitHub link icon in the header next to the module selector, directing users to the project repository in a new tab.

- Refactor
  - Cleaned up type import paths for improved consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->